### PR TITLE
User feedback in settings

### DIFF
--- a/src/components/Buttons/MigrateButton/index.tsx
+++ b/src/components/Buttons/MigrateButton/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, useDisclosure } from '@chakra-ui/react';
 import { useRecoilState } from 'recoil';
-import { migrationItemsState } from '../../state/migrate';
-import { MigrateModal } from '../MigrateModal';
+import { migrationItemsState } from '../../../state/migrate';
+import { MigrateModal } from '../../Modal/MigrateModal';
 
 export function MigrateButton() {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/src/components/Buttons/SettingsButton/index.tsx
+++ b/src/components/Buttons/SettingsButton/index.tsx
@@ -1,0 +1,23 @@
+import { Box, theme, useDisclosure } from '@chakra-ui/react';
+import { Setting2 } from 'iconsax-react';
+import { SettingsModal } from '../../Modal/SettingsModal';
+
+export function SettingsButton() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <Box
+        role="button"
+        cursor="pointer"
+        padding="2"
+        borderRadius="lg"
+        onClick={onOpen}
+        boxShadow="xs"
+      >
+        <Setting2 size="24" color={theme.colors.teal[500]} />
+      </Box>
+      <SettingsModal isOpen={isOpen} onClose={onClose} />
+    </>
+  );
+}

--- a/src/components/ContentTypesTable/Badges/ContentType.tsx
+++ b/src/components/ContentTypesTable/Badges/ContentType.tsx
@@ -1,24 +1,22 @@
 import { Badge } from '@chakra-ui/react';
 import { ContentType } from 'contentful-management';
-import { SpaceData } from '../../../api';
+import { useRecoilValue } from 'recoil';
+import { mainBranchState } from '../../../state/settings';
 import { getContentTypeInfoInMaster } from '../utils';
 
 interface ContentTypeBadgeProps {
   contentType: ContentType;
-  spaceData: SpaceData;
 }
 
-export function ContentTypeBadge({
-  contentType,
-  spaceData,
-}: ContentTypeBadgeProps) {
+export function ContentTypeBadge({ contentType }: ContentTypeBadgeProps) {
+  const mainBranch = useRecoilValue(mainBranchState);
   /**
    * TODO: Write JSDoc
    * @param contentType
    * @returns
    */
   const isContentTypeInSyncWithMaster = () => {
-    const info = getContentTypeInfoInMaster(spaceData, contentType);
+    const info = getContentTypeInfoInMaster(mainBranch!, contentType);
     const { contentTypesInMaster, contentTypeIndex } = info;
 
     if (contentTypeIndex < 0) {
@@ -37,12 +35,12 @@ export function ContentTypeBadge({
     }
 
     const inSync = contentType.fields.every((field) => {
-      const fieldInMasterConentType = contentTypesInMaster[
+      const fieldInMasterContentType = contentTypesInMaster[
         contentTypeIndex
       ].fields.find((fieldItem) => fieldItem.id === field.id);
       return (
-        fieldInMasterConentType &&
-        JSON.stringify(field) === JSON.stringify(fieldInMasterConentType)
+        fieldInMasterContentType &&
+        JSON.stringify(field) === JSON.stringify(fieldInMasterContentType)
       );
     });
 

--- a/src/components/ContentTypesTable/Badges/Field.tsx
+++ b/src/components/ContentTypesTable/Badges/Field.tsx
@@ -1,15 +1,16 @@
 import { Badge } from '@chakra-ui/react';
 import { ContentFields, ContentType, KeyValueMap } from 'contentful-management';
-import { SpaceData } from '../../../api';
+import { useRecoilValue } from 'recoil';
+import { mainBranchState } from '../../../state/settings';
 import { getContentTypeInfoInMaster, getFieldIndex } from '../utils';
 
 interface FieldBadgeProps {
   contentType: ContentType;
-  spaceData: SpaceData;
   field: ContentFields<KeyValueMap>;
 }
 
-export function FieldBadge({ contentType, spaceData, field }: FieldBadgeProps) {
+export function FieldBadge({ contentType, field }: FieldBadgeProps) {
+  const mainBranch = useRecoilValue(mainBranchState);
   /**
    * TODO: Write JSDoc
    * @param contentType
@@ -17,7 +18,7 @@ export function FieldBadge({ contentType, spaceData, field }: FieldBadgeProps) {
    * @returns
    */
   const isFieldExisting = () => {
-    const info = getContentTypeInfoInMaster(spaceData, contentType);
+    const info = getContentTypeInfoInMaster(mainBranch!, contentType);
     const { contentTypesInMaster, contentTypeIndex } = info;
 
     if (contentTypeIndex < 0) {
@@ -39,7 +40,7 @@ export function FieldBadge({ contentType, spaceData, field }: FieldBadgeProps) {
    * @returns
    */
   const isFieldInSync = () => {
-    const info = getContentTypeInfoInMaster(spaceData, contentType);
+    const info = getContentTypeInfoInMaster(mainBranch!, contentType);
     const { contentTypesInMaster, contentTypeIndex } = info;
 
     if (contentTypeIndex < 0) {

--- a/src/components/ContentTypesTable/index.tsx
+++ b/src/components/ContentTypesTable/index.tsx
@@ -212,10 +212,7 @@ export function ContentTypesTable({
                   </Td>
                   <Td>
                     {!!spaceData && (
-                      <ContentTypeBadge
-                        spaceData={spaceData}
-                        contentType={contentType}
-                      />
+                      <ContentTypeBadge contentType={contentType} />
                     )}
                   </Td>
                   <Td>
@@ -269,7 +266,6 @@ export function ContentTypesTable({
                                   <Td>
                                     {!!spaceData && (
                                       <FieldBadge
-                                        spaceData={spaceData}
                                         contentType={contentType}
                                         field={field}
                                       />

--- a/src/components/ContentTypesTable/utils.ts
+++ b/src/components/ContentTypesTable/utils.ts
@@ -1,5 +1,5 @@
 import { ContentFields, ContentType, KeyValueMap } from 'contentful-management';
-import { SpaceData } from '../../api';
+import { ContentfulEnvironmentWithContentTypes } from '../../api';
 
 /**
  * TODO: Write JSDoc
@@ -21,11 +21,10 @@ export const getContentTypeIndex = (
  * @returns
  */
 export const getContentTypeInfoInMaster = (
-  spaceData: SpaceData | null,
+  mainBranch: ContentfulEnvironmentWithContentTypes,
   contentType: ContentType
 ) => {
-  const contentTypesInMaster =
-    spaceData?.environmentsWithContentTypes[0]?.contentTypes;
+  const contentTypesInMaster = mainBranch?.contentTypes;
 
   const contentTypeIndex = getContentTypeIndex(
     contentType,

--- a/src/components/Modal/MigrateModal/index.tsx
+++ b/src/components/Modal/MigrateModal/index.tsx
@@ -20,19 +20,19 @@ import {
 import { ArrowSwapHorizontal, Card, Hierarchy2 } from 'iconsax-react';
 import { ChangeEvent, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { migrationItemsState } from '../../state/migrate';
+import { migrationItemsState } from '../../../state/migrate';
 import {
   allEnvironmentState,
   currentEnvironmentState,
   triggerState,
-} from '../../state/space';
+} from '../../../state/space';
 
 import {
   createContentType,
   /* createContentType, */
   getEnvironement,
   updateContentType,
-} from '../../api/contentType/migrations';
+} from '../../../api/contentType/migrations';
 
 interface MigrateModalProps {
   isOpen: boolean;

--- a/src/components/Modal/SettingsModal/index.tsx
+++ b/src/components/Modal/SettingsModal/index.tsx
@@ -40,35 +40,47 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     event: ChangeEvent<HTMLSelectElement>,
     settingType: ValueOf<typeof SettingTypes>
   ) => {
-    setSettings({
-      ...settings,
-      [settingType]: event.target.value,
-    });
+    try {
+      setSettings({
+        ...settings,
+        [settingType]: event.target.value,
+      });
 
-    await setSettingsInStorage({
-      ...settings,
-      [settingType]: event.target.value,
-    });
+      await setSettingsInStorage({
+        ...settings,
+        [settingType]: event.target.value,
+      });
 
-    let description = '';
-    switch (settingType) {
-      case SettingTypes.MAIN_BRANCH: {
-        description = 'Successfully switched the main branch.';
-        break;
+      let description = '';
+      switch (settingType) {
+        case SettingTypes.MAIN_BRANCH: {
+          description = 'Successfully switched the main branch.';
+          break;
+        }
+        default: {
+          description = '';
+        }
       }
-      default: {
-        description = '';
-      }
+
+      toast({
+        title: 'Settings changed.',
+        description,
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Oops.',
+        description: 'Something went wrong.',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
     }
-
-    toast({
-      title: 'Settings changed.',
-      description,
-      status: 'success',
-      duration: 3000,
-      isClosable: true,
-    });
   };
+
   return (
     <Modal size="full" isOpen={isOpen} onClose={onClose} isCentered>
       <ModalContent>

--- a/src/components/Modal/SettingsModal/index.tsx
+++ b/src/components/Modal/SettingsModal/index.tsx
@@ -1,35 +1,87 @@
 /* eslint-disable no-await-in-loop */
 import {
   Modal,
-  ModalOverlay,
   ModalContent,
   ModalHeader,
-  ModalFooter,
   ModalBody,
   ModalCloseButton,
+  Heading,
+  Box,
+  Text,
+  Select,
+  Flex,
 } from '@chakra-ui/react';
+import { ChangeEvent } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { settingsState } from '../../../state/settings';
+import { allEnvironmentState } from '../../../state/space';
 
 interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
-  return (
-    <Modal
-      size="xl"
-      isOpen={isOpen}
-      onClose={onClose}
-      motionPreset="slideInBottom"
-      isCentered
-    >
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader />
-        <ModalCloseButton />
-        <ModalBody>Body</ModalBody>
+const SettingTypes = {
+  MAIN_BRANCH: 'mainBranch',
+};
 
-        <ModalFooter>Footer</ModalFooter>
+type ValueOf<T> = T[keyof T];
+
+export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const allEnvironments = useRecoilValue(allEnvironmentState);
+  const [settings, setSettings] = useRecoilState(settingsState);
+
+  const handleOnChange = (
+    event: ChangeEvent<HTMLSelectElement>,
+    settingType: ValueOf<typeof SettingTypes>
+  ) => {
+    setSettings({
+      ...settings,
+      [settingType]: event.target.value,
+    });
+  };
+  return (
+    <Modal size="full" isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalContent>
+        <ModalHeader>
+          <Heading as="h2" size="lg" isTruncated>
+            Settings
+          </Heading>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Flex marginTop="5" paddingRight="5">
+            <Box width="50%">
+              <Heading as="h3" size="sm" isTruncated>
+                Main Branch
+              </Heading>
+              <Box marginTop="4" maxWidth="75%">
+                <Text fontSize="xs">
+                  The main branch inherits the content contentTypes of your
+                  website. If you select another main branch, the other branches
+                  are compared against the main branch. Thus one can determine
+                  which ContentType are not synchronized with the main branch.
+                </Text>
+              </Box>
+            </Box>
+            <Flex alignItems="center" width="50%">
+              <Select
+                width="100%"
+                marginTop="4"
+                size="md"
+                onChange={(event) =>
+                  handleOnChange(event, SettingTypes.MAIN_BRANCH)
+                }
+              >
+                {allEnvironments?.map((environment) => (
+                  <option key={environment.name} value={environment.name}>
+                    {environment.name}
+                  </option>
+                ))}
+              </Select>
+            </Flex>
+          </Flex>
+        </ModalBody>
       </ModalContent>
     </Modal>
   );

--- a/src/components/Modal/SettingsModal/index.tsx
+++ b/src/components/Modal/SettingsModal/index.tsx
@@ -10,11 +10,13 @@ import {
   Text,
   Select,
   Flex,
+  useToast,
 } from '@chakra-ui/react';
 import { ChangeEvent } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { settingsState } from '../../../state/settings';
 import { allEnvironmentState } from '../../../state/space';
+import { setSettingsInStorage } from '../../../storage/settings';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -28,17 +30,43 @@ const SettingTypes = {
 type ValueOf<T> = T[keyof T];
 
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const toast = useToast();
+
   const allEnvironments = useRecoilValue(allEnvironmentState);
   const [settings, setSettings] = useRecoilState(settingsState);
 
   // TODO: Set dropdown value to settings mainBranch from localstorage
-  const handleOnChange = (
+  const handleOnChange = async (
     event: ChangeEvent<HTMLSelectElement>,
     settingType: ValueOf<typeof SettingTypes>
   ) => {
     setSettings({
       ...settings,
       [settingType]: event.target.value,
+    });
+
+    await setSettingsInStorage({
+      ...settings,
+      [settingType]: event.target.value,
+    });
+
+    let description = '';
+    switch (settingType) {
+      case SettingTypes.MAIN_BRANCH: {
+        description = 'Successfully switched the main branch.';
+        break;
+      }
+      default: {
+        description = '';
+      }
+    }
+
+    toast({
+      title: 'Settings changed.',
+      description,
+      status: 'success',
+      duration: 3000,
+      isClosable: true,
     });
   };
   return (

--- a/src/components/Modal/SettingsModal/index.tsx
+++ b/src/components/Modal/SettingsModal/index.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable no-await-in-loop */
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+} from '@chakra-ui/react';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  return (
+    <Modal
+      size="xl"
+      isOpen={isOpen}
+      onClose={onClose}
+      motionPreset="slideInBottom"
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader />
+        <ModalCloseButton />
+        <ModalBody>Body</ModalBody>
+
+        <ModalFooter>Footer</ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/Modal/SettingsModal/index.tsx
+++ b/src/components/Modal/SettingsModal/index.tsx
@@ -31,6 +31,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const allEnvironments = useRecoilValue(allEnvironmentState);
   const [settings, setSettings] = useRecoilState(settingsState);
 
+  // TODO: Set dropdown value to settings mainBranch from localstorage
   const handleOnChange = (
     event: ChangeEvent<HTMLSelectElement>,
     settingType: ValueOf<typeof SettingTypes>
@@ -69,6 +70,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                 width="100%"
                 marginTop="4"
                 size="md"
+                value={settings.mainBranch!}
                 onChange={(event) =>
                   handleOnChange(event, SettingTypes.MAIN_BRANCH)
                 }

--- a/src/components/Navigation/NavigationItem/index.tsx
+++ b/src/components/Navigation/NavigationItem/index.tsx
@@ -6,6 +6,7 @@ interface NavigationItemProps {
   environment: Environment;
   // eslint-disable-next-line react/require-default-props
   active?: boolean;
+  isMain: boolean;
   handleOnClick: () => void;
 }
 
@@ -14,6 +15,7 @@ const color = theme.colors.teal['500'];
 export function NavigationItem({
   environment,
   active,
+  isMain,
   handleOnClick,
 }: NavigationItemProps) {
   return (
@@ -47,16 +49,19 @@ export function NavigationItem({
             />
           </Box>
 
-          <Text
-            transition="all 0.3s ease"
-            fontWeight="bold"
-            fontSize="sm"
-            textTransform="capitalize"
-            color={active ? 'black' : `${color}`}
-            letterSpacing="0.5px"
-          >
-            {environment?.name}
-          </Text>
+          <Box>
+            <Text
+              transition="all 0.3s ease"
+              fontWeight="bold"
+              fontSize="sm"
+              textTransform="capitalize"
+              color={active ? 'black' : `${color}`}
+              letterSpacing="0.5px"
+            >
+              {environment?.name}
+            </Text>
+            {isMain && <Text fontSize="xs">Main</Text>}
+          </Box>
         </HStack>
       </Box>
     </Box>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,8 @@ import reportWebVitals from './reportWebVitals';
 import Home from './pages/Home';
 import theme from './theme';
 import GlobalStyles from './styles';
-import { ContentfulSpace } from './state/space';
+import { ContentfulSpace } from './state/handler/space';
+import { Settings } from './state/handler/settings';
 import { getClient } from './api/client';
 
 export const client = getClient();
@@ -18,6 +19,7 @@ ReactDOM.render(
     <RecoilRoot>
       <ChakraProvider theme={theme}>
         <ContentfulSpace />
+        <Settings />
         <GlobalStyles />
         <Router>
           <Routes>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@chakra-ui/react';
 import { useRecoilState } from 'recoil';
-import { MigrateButton } from '../../components/MigrateButton';
+import { MigrateButton } from '../../components/Buttons/MigrateButton';
 import { Header } from '../../partials/Header';
 import { Main } from '../../partials/Main';
 

--- a/src/partials/Header/index.tsx
+++ b/src/partials/Header/index.tsx
@@ -1,13 +1,19 @@
-import { Box, HStack, Skeleton, Text, VStack } from '@chakra-ui/react';
+import { Flex, HStack, Skeleton, Text, VStack } from '@chakra-ui/react';
 import { useRecoilState } from 'recoil';
 import { spaceState } from '../../state/space';
+import { SettingsButton } from '../../components/Buttons/SettingsButton';
 
 export function Header() {
   // eslint-disable-next-line no-unused-vars
   const [spaceData, setSpaceData] = useRecoilState(spaceState);
 
   return (
-    <Box paddingX={10} paddingY={15}>
+    <Flex
+      paddingX={10}
+      paddingY={15}
+      justifyContent="space-between"
+      alignItems="center"
+    >
       <VStack alignItems="flex-start">
         <HStack>
           <Text fontWeight="bold" textTransform="uppercase" fontSize="sm">
@@ -30,6 +36,9 @@ export function Header() {
           )}
         </HStack>
       </VStack>
-    </Box>
+      <HStack>
+        <SettingsButton />
+      </HStack>
+    </Flex>
   );
 }

--- a/src/partials/Sidebar/index.tsx
+++ b/src/partials/Sidebar/index.tsx
@@ -57,6 +57,7 @@ function Sidebar() {
           spaceData?.environmentsWithContentTypes.map(
             ({ environment }, index) => (
               <NavigationItem
+                isMain={index === 0}
                 active={index === currentEnvironmentIndex}
                 handleOnClick={() => setcurrentEnvironmentIndex(index)}
                 environment={environment}

--- a/src/state/handler/settings.tsx
+++ b/src/state/handler/settings.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { spaceState } from '../space';
+import { getSettingsFromStorage } from '../../storage/settings';
+import { settingsState } from '../settings';
+
+export function Settings() {
+  // eslint-disable-next-line no-unused-vars
+  const [settings, _] = useRecoilState(settingsState);
+  // eslint-disable-next-line no-unused-vars
+  const [spaceData, __] = useRecoilState(spaceState);
+
+  useEffect(() => {
+    if (spaceData) {
+      // Set first environment as mainBranch defaultly
+      localStorage.setItem(
+        'cma_settings',
+        JSON.stringify({
+          ...settings,
+          mainBranch:
+            spaceData?.environmentsWithContentTypes[0].environment.sys.id,
+        })
+      );
+      return;
+    }
+
+    const settingsInStorage = getSettingsFromStorage();
+    if (!settingsInStorage) {
+      return;
+    }
+
+    // Set mainBranch when settings changed
+    if (settingsInStorage.mainBranch !== settings.mainBranch) {
+      localStorage.setItem('cma_settings', JSON.stringify(settings));
+    }
+  }, [settings, spaceData]);
+
+  return null;
+}

--- a/src/state/handler/settings.tsx
+++ b/src/state/handler/settings.tsx
@@ -6,9 +6,15 @@ import { settingsState } from '../settings';
 
 export function Settings() {
   // eslint-disable-next-line no-unused-vars
-  const [settings, _] = useRecoilState(settingsState);
+  const [settings, setSettings] = useRecoilState(settingsState);
   // eslint-disable-next-line no-unused-vars
-  const [spaceData, __] = useRecoilState(spaceState);
+  const [spaceData, _] = useRecoilState(spaceState);
+
+  useEffect(() => {
+    const settingsInStorage = getSettingsFromStorage();
+
+    setSettings(settingsInStorage!);
+  }, []);
 
   useEffect(() => {
     if (spaceData) {
@@ -21,10 +27,10 @@ export function Settings() {
             spaceData?.environmentsWithContentTypes[0].environment.sys.id,
         })
       );
-      return;
     }
 
     const settingsInStorage = getSettingsFromStorage();
+
     if (!settingsInStorage) {
       return;
     }

--- a/src/state/handler/space.tsx
+++ b/src/state/handler/space.tsx
@@ -1,12 +1,15 @@
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useEffect } from 'react';
 import { getSpaceData } from '../../api';
 import { spaceState, triggerState } from '../space';
+import { mainBranchState } from '../settings';
 
 export function ContentfulSpace() {
   // eslint-disable-next-line no-unused-vars
   const [spaceData, setSpaceData] = useRecoilState(spaceState);
   const [trigger, setTrigger] = useRecoilState(triggerState);
+
+  const mainBranch = useRecoilValue(mainBranchState);
 
   useEffect(() => {
     const fetchSpaceData = async () => {
@@ -23,6 +26,41 @@ export function ContentfulSpace() {
       setTrigger(false);
     }
   }, [trigger, spaceData]);
+
+  useEffect(() => {
+    if (!spaceData) {
+      return;
+    }
+
+    if (spaceData?.environmentsWithContentTypes?.length <= 1) {
+      return;
+    }
+
+    // If the first item of the environments already is the mainBranch, just leave it
+    if (
+      spaceData?.environmentsWithContentTypes[0].environment.sys.id ===
+      mainBranch?.environment.sys.id
+    ) {
+      return;
+    }
+
+    const copy = { ...spaceData };
+    const mainEnv = copy.environmentsWithContentTypes?.find(
+      (env) => env?.environment?.sys?.id === mainBranch?.environment.sys.id
+    );
+
+    if (!mainEnv) {
+      return;
+    }
+    const mainEnvCopy = { ...mainEnv };
+
+    const filtered = copy.environmentsWithContentTypes.filter(
+      (env) => env.environment.sys.id !== mainEnv.environment.sys.id
+    );
+
+    copy.environmentsWithContentTypes = [mainEnvCopy, ...filtered];
+    setSpaceData(copy);
+  }, [mainBranch]);
 
   return null;
 }

--- a/src/state/handler/space.tsx
+++ b/src/state/handler/space.tsx
@@ -1,0 +1,28 @@
+import { useRecoilState } from 'recoil';
+import { useEffect } from 'react';
+import { getSpaceData } from '../../api';
+import { spaceState, triggerState } from '../space';
+
+export function ContentfulSpace() {
+  // eslint-disable-next-line no-unused-vars
+  const [spaceData, setSpaceData] = useRecoilState(spaceState);
+  const [trigger, setTrigger] = useRecoilState(triggerState);
+
+  useEffect(() => {
+    const fetchSpaceData = async () => {
+      const response = await getSpaceData();
+      setSpaceData(response);
+    };
+
+    if (!spaceData) {
+      fetchSpaceData();
+    }
+
+    if (trigger) {
+      fetchSpaceData();
+      setTrigger(false);
+    }
+  }, [trigger, spaceData]);
+
+  return null;
+}

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,7 +1,8 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
+import { spaceState } from './space';
 
 const SETTINGS_STATE_KEY = 'settingsState';
-
+const MAIN_BRANCH_STATE_KEY = 'mainBranchState';
 export interface SettingsProps {
   mainBranch: string | null;
 }
@@ -11,4 +12,18 @@ export const settingsState = atom<SettingsProps>({
   default: {
     mainBranch: null,
   } as SettingsProps,
+});
+
+export const mainBranchState = selector({
+  key: MAIN_BRANCH_STATE_KEY,
+  get: ({ get }) => {
+    const spaceData = get(spaceState);
+    const settingsData = get(settingsState);
+
+    const mainBranch = spaceData?.environmentsWithContentTypes.find(
+      (env) => env.environment.sys.id === settingsData.mainBranch
+    );
+
+    return mainBranch;
+  },
 });

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+
+const SETTINGS_STATE_KEY = 'settingsState';
+
+export interface SettingsProps {
+  mainBranch: string | null;
+}
+
+export const settingsState = atom<SettingsProps>({
+  key: SETTINGS_STATE_KEY,
+  default: {
+    mainBranch: null,
+  } as SettingsProps,
+});

--- a/src/state/space.ts
+++ b/src/state/space.ts
@@ -3,7 +3,9 @@ import { SpaceData } from '../api';
 
 const SPACE_STATE_KEY = 'spaceState';
 const TRIGGER_STATE_KEY = 'triggerState';
-const CURRENT_ENVIRONMENT_STATE_KEY = 'currentEnvironmentIndexState';
+const CURRENT_ENVIRONMENT_INDEX_STATE_KEY = 'currentEnvironmentIndexState';
+const CURRENT_ENVIRONMENT_STATE_KEY = 'currentEnvironmentState';
+const ALL_ENVIRONMENTS_STATE_KEY = 'allEnvironmentsState';
 
 export const spaceState = atom<SpaceData | null>({
   key: SPACE_STATE_KEY,
@@ -11,7 +13,7 @@ export const spaceState = atom<SpaceData | null>({
 });
 
 export const currentEnvironmentIndexState = atom<number>({
-  key: CURRENT_ENVIRONMENT_STATE_KEY,
+  key: CURRENT_ENVIRONMENT_INDEX_STATE_KEY,
   default: 0,
 });
 
@@ -21,7 +23,7 @@ export const triggerState = atom<boolean>({
 });
 
 export const currentEnvironmentState = selector({
-  key: 'currentEnvironmentState',
+  key: CURRENT_ENVIRONMENT_STATE_KEY,
   get: ({ get }) => {
     const currentIndex = get(currentEnvironmentIndexState);
     const spaceData = get(spaceState);
@@ -30,7 +32,7 @@ export const currentEnvironmentState = selector({
 });
 
 export const allEnvironmentState = selector({
-  key: 'allEnvironmentsState',
+  key: ALL_ENVIRONMENTS_STATE_KEY,
   get: ({ get }) => {
     const spaceData = get(spaceState);
     return spaceData?.environmentsWithContentTypes.map(

--- a/src/state/space.ts
+++ b/src/state/space.ts
@@ -1,7 +1,5 @@
-import { atom, selector, useRecoilState } from 'recoil';
-
-import { useEffect } from 'react';
-import { getSpaceData, SpaceData } from '../api';
+import { atom, selector } from 'recoil';
+import { SpaceData } from '../api';
 
 const SPACE_STATE_KEY = 'spaceState';
 const TRIGGER_STATE_KEY = 'triggerState';
@@ -40,27 +38,3 @@ export const allEnvironmentState = selector({
     );
   },
 });
-
-export function ContentfulSpace() {
-  // eslint-disable-next-line no-unused-vars
-  const [spaceData, setSpaceData] = useRecoilState(spaceState);
-  const [trigger, setTrigger] = useRecoilState(triggerState);
-
-  useEffect(() => {
-    const fetchSpaceData = async () => {
-      const response = await getSpaceData();
-      setSpaceData(response);
-    };
-
-    if (!spaceData) {
-      fetchSpaceData();
-    }
-
-    if (trigger) {
-      fetchSpaceData();
-      setTrigger(false);
-    }
-  }, [trigger, spaceData]);
-
-  return null;
-}

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -2,15 +2,30 @@ import { SettingsProps } from '../state/settings';
 
 const SETTINGS_LOCALSTORAGE_KEY = 'cma_settings';
 
-export const setSettingsInStorage = (settings: SettingsProps) => {
-  localStorage.setItem(SETTINGS_LOCALSTORAGE_KEY, JSON.stringify(settings));
-};
+export const setSettingsInStorage = (
+  settings: SettingsProps
+): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    try {
+      localStorage.setItem(SETTINGS_LOCALSTORAGE_KEY, JSON.stringify(settings));
+      resolve(true);
+    } catch (e) {
+      reject(e);
+    }
+  });
 
-export const getSettingsFromStorage = (): SettingsProps | null => {
-  const settingsInStorage = localStorage.getItem(SETTINGS_LOCALSTORAGE_KEY);
+export const getSettingsFromStorage = (): Promise<SettingsProps | null> =>
+  new Promise((resolve, reject) => {
+    try {
+      const settingsInStorage = localStorage.getItem(SETTINGS_LOCALSTORAGE_KEY);
 
-  if (!settingsInStorage) {
-    return null;
-  }
-  return JSON.parse(settingsInStorage) as SettingsProps;
-};
+      if (settingsInStorage === null) {
+        resolve(null);
+      }
+
+      const parsed = JSON.parse(settingsInStorage!) as SettingsProps;
+      resolve(parsed);
+    } catch (e) {
+      reject(e);
+    }
+  });

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -1,0 +1,16 @@
+import { SettingsProps } from '../state/settings';
+
+const SETTINGS_LOCALSTORAGE_KEY = 'cma_settings';
+
+export const setSettingsInStorage = (settings: SettingsProps) => {
+  localStorage.setItem(SETTINGS_LOCALSTORAGE_KEY, JSON.stringify(settings));
+};
+
+export const getSettingsFromStorage = (): SettingsProps | null => {
+  const settingsInStorage = localStorage.getItem(SETTINGS_LOCALSTORAGE_KEY);
+
+  if (!settingsInStorage) {
+    return null;
+  }
+  return JSON.parse(settingsInStorage) as SettingsProps;
+};


### PR DESCRIPTION
In order to give the user feedback if something in the settings were persisted successfully or not, there should be an ui interaction, that shows the user the feedback in the frontend.
Currently there is only on option in the settings to change, so the feedback will focus on the main branch settings.

- [x] show positive feedback when main branch changed successfully
- [x] show negative feedback when main branch changed and it failed